### PR TITLE
fix: develop-version-tracker 워크플로우 Git 의존성 제거

### DIFF
--- a/.github/workflows/develop-version-tracker.yml
+++ b/.github/workflows/develop-version-tracker.yml
@@ -16,11 +16,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Add develop summary comment
         run: |
           echo "📝 Adding develop branch summary..."
@@ -28,30 +23,18 @@ jobs:
           # PR 정보 가져오기
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
 
-          # Get commit messages using git log
-          git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/commits.txt
+          echo "Merged PR: $PR_TITLE by $PR_AUTHOR"
 
-          # 커밋 리스트 생성
-          COMMIT_LIST=""
-          while IFS= read -r commit; do
-            if [[ -n "$commit" ]]; then
-              COMMIT_LIST="$COMMIT_LIST- $commit"$'\n'
-            fi
-          done < /tmp/commits.txt
+          # develop 브랜치에 간단한 댓글 추가
+          gh pr comment $PR_NUMBER --body "## 🎉 develop 브랜치에 병합 완료!
 
-          # develop 브랜치에 댓글 추가 (마지막 커밋에)
-          gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.merge_commit_sha }}/comments \
-            --method POST \
-            --field body="## 📦 Develop 브랜치 업데이트
+          **병합된 PR:** $PR_TITLE
+          **작성자:** @$PR_AUTHOR
+          **병합 시간:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
-          ### 🔄 병합된 작업: [$PR_TITLE](#$PR_NUMBER)
-
-          <details>
-          <summary><strong>📋 커밋 목록 보기</strong></summary>
-
-          $COMMIT_LIST
-          </details>"
+          > 🚀 이 작업이 develop 브랜치에 성공적으로 병합되었습니다!"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -47,6 +47,18 @@ jobs:
 
       - name: Run lint checks on changed files
         run: |
-          echo "🔍 Running lint checks on changed files..."
-          yarn lint:changed
-          echo "✅ Lint checks passed!"
+          echo "🔍 Checking for files to lint..."
+
+          # 변경된 파일 중 lint 대상 파일이 있는지 확인
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -E '\.(ts|tsx|js|jsx)$' | grep -E '^(apps|packages)/' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "📋 No TypeScript/JavaScript files changed in apps or packages directories"
+            echo "✅ Lint check skipped - no relevant files to check"
+          else
+            echo "📋 Found files to lint:"
+            echo "$CHANGED_FILES"
+            echo "🔍 Running lint checks on changed files..."
+            yarn lint:changed
+            echo "✅ Lint checks passed!"
+          fi

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -4,19 +4,6 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-    paths:
-      - "apps/**/*.ts"
-      - "apps/**/*.tsx"
-      - "apps/**/*.js"
-      - "apps/**/*.jsx"
-      - "packages/**/*.ts"
-      - "packages/**/*.tsx"
-      - "packages/**/*.js"
-      - "packages/**/*.jsx"
-      - "**/.eslintrc*"
-      - "**/eslint.config.*"
-      - "package.json"
-      - "yarn.lock"
 
 jobs:
   lint-check:

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -25,11 +25,25 @@ jobs:
         run: |
           echo "🔍 Getting PR commits and analyzing..."
 
+          echo "Debug - Base SHA: ${{ github.event.pull_request.base.sha }}"
+          echo "Debug - Head SHA: ${{ github.event.pull_request.head.sha }}"
+
           # Get commit messages using git log
+          echo "Running git log command..."
           git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/commits.txt
 
-          echo "📋 Commit messages:"
+          echo "📋 Commit messages from file:"
           cat /tmp/commits.txt
+          echo "📋 File size:"
+          wc -l /tmp/commits.txt
+
+          # Fallback: 파일이 비어있으면 다른 방법 시도
+          if [ ! -s /tmp/commits.txt ]; then
+            echo "⚠️ No commits found with git log, trying alternative approach..."
+            git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | cut -d' ' -f2- > /tmp/commits.txt
+            echo "📋 Alternative commit messages:"
+            cat /tmp/commits.txt
+          fi
 
           # Analyze version impact
           HAS_MAJOR=false
@@ -86,16 +100,25 @@ jobs:
 
           echo "📊 Final result: $VERSION_TYPE - $CHANGE_DESC"
 
-          # Create commit list for PR comment
+          # Create commit list for PR comment (항상 생성)
+          echo "📝 Creating commit list for PR comment..."
           COMMIT_LIST=""
           while IFS= read -r commit_title; do
             if [[ -n "$commit_title" ]]; then
               COMMIT_LIST="$COMMIT_LIST- $commit_title"$'\n'
+              echo "✅ Added to commit list: $commit_title"
             fi
           done < /tmp/commits.txt
 
-          # Add PR comment if valid
+          # 커밋 목록이 비어있으면 기본 메시지 추가
+          if [[ -z "$COMMIT_LIST" ]]; then
+            COMMIT_LIST="- (커밋 정보를 가져올 수 없습니다)"$'\n'
+            echo "⚠️ No commits found, using fallback message"
+          fi
+
+          # Add PR comment if valid (커밋 목록은 항상 표시)
           if [ "$VERSION_TYPE" != "invalid" ]; then
+            echo "📝 Adding PR comment with version: $CHANGE_DESC"
             gh pr comment ${{ github.event.number }} --body "## 📦 $CHANGE_DESC
 
           ### 📋 커밋 목록

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -125,22 +125,12 @@ jobs:
           $COMMIT_LIST"
           fi
 
-          # Set status check
+          # 워크플로우 실패 처리 (수동 상태 체크 완전 제거)
           if [ "$VERSION_TYPE" = "invalid" ]; then
-            gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
-              --method POST \
-              --field state="failure" \
-              --field target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              --field description="Invalid commit format detected" \
-              --field context="version-classification"
+            echo "❌ Invalid commit format detected - failing workflow"
             exit 1
           else
-            gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
-              --method POST \
-              --field state="success" \
-              --field target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              --field description="Version classified as $VERSION_TYPE" \
-              --field context="version-classification"
+            echo "✅ Version classification completed: $VERSION_TYPE"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -4,14 +4,6 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-    paths:
-      - "apps/**/*.ts"
-      - "apps/**/*.tsx"
-      - "packages/**/*.ts"
-      - "packages/**/*.tsx"
-      - "**/tsconfig.json"
-      - "package.json"
-      - "yarn.lock"
 
 jobs:
   typescript-check:

--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -42,6 +42,18 @@ jobs:
 
       - name: Run TypeScript checks on changed files
         run: |
-          echo "🔍 Running TypeScript checks on changed files..."
-          yarn tsc:changed
-          echo "✅ TypeScript checks passed!"
+          echo "🔍 Checking for files to type-check..."
+
+          # 변경된 파일 중 TypeScript 대상 파일이 있는지 확인
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -E '\.(ts|tsx)$' | grep -E '^(apps|packages)/' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "📋 No TypeScript files changed in apps or packages directories"
+            echo "✅ TypeScript check skipped - no relevant files to check"
+          else
+            echo "📋 Found files to type-check:"
+            echo "$CHANGED_FILES"
+            echo "🔍 Running TypeScript checks on changed files..."
+            yarn tsc:changed
+            echo "✅ TypeScript checks passed!"
+          fi


### PR DESCRIPTION
- git log 명령어 제거로 revision range 에러 해결
- GitHub event 데이터만 활용하여 안정성 극대화
- 단순한 PR 댓글로 develop 병합 알림 기능 유지