### PR TITLE
fix: git revision range 오류 해결 및 GitHub API 사용으로 개선

### DIFF
--- a/.github/workflows/develop-version-tracker.yml
+++ b/.github/workflows/develop-version-tracker.yml
@@ -44,20 +44,28 @@ jobs:
 
           echo "✅ Merged PR: #$MERGED_PR_NUMBER - $MERGED_PR_TITLE by $MERGED_PR_AUTHOR"
 
-          # 병합된 PR의 커밋 목록 가져오기
-          echo "📝 Getting commit list from merged PR..."
-          git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/merged_commits.txt
+          # 병합된 PR의 커밋 목록을 GitHub API를 통해 가져오기
+          echo "📝 Getting commit list from merged PR using GitHub API..."
 
+          # GitHub API를 통해 PR의 커밋 목록 가져오기
           COMMIT_LIST=""
-          while IFS= read -r commit_title; do
-            if [[ -n "$commit_title" ]]; then
-              COMMIT_LIST="$COMMIT_LIST- $commit_title"$'\n'
-            fi
-          done < /tmp/merged_commits.txt
+          COMMITS_JSON=$(gh api repos/${{ github.repository }}/pulls/$MERGED_PR_NUMBER/commits)
+
+          if [ -n "$COMMITS_JSON" ]; then
+            echo "$COMMITS_JSON" | jq -r '.[].commit.message' | while IFS= read -r commit_message; do
+              if [[ -n "$commit_message" ]]; then
+                # 첫 번째 줄만 가져오기 (커밋 제목)
+                COMMIT_TITLE=$(echo "$commit_message" | head -1)
+                COMMIT_LIST="$COMMIT_LIST- $COMMIT_TITLE"$'\n'
+                echo "✅ Added commit: $COMMIT_TITLE"
+              fi
+            done
+          fi
 
           # 커밋 목록이 비어있으면 기본 메시지 추가
           if [[ -z "$COMMIT_LIST" ]]; then
             COMMIT_LIST="- (커밋 정보를 가져올 수 없습니다)"$'\n'
+            echo "⚠️ No commits found, using fallback message"
           fi
 
           # 현재 버전 정보 (0.0.0에서 시작)

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -31,21 +31,29 @@ jobs:
 
           # GitHub API를 통해 PR의 커밋 목록 가져오기
           echo "📝 Getting commit list using GitHub API..."
-          COMMITS_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/commits)
           
-          # 커밋 메시지를 임시 파일에 저장
-          echo "$COMMITS_JSON" | jq -r '.[].commit.message' > /tmp/commits.txt
-
-          echo "📋 Commit messages from API:"
+          # 현재 PR의 base SHA와 head SHA를 사용하여 커밋 범위 지정
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          
+          echo "Debug - Base SHA: $BASE_SHA"
+          echo "Debug - Head SHA: $HEAD_SHA"
+          
+          # git log를 사용하여 정확한 커밋 범위에서 커밋 가져오기
+          git log --pretty=format:"%s" $BASE_SHA..$HEAD_SHA > /tmp/commits.txt
+          
+          echo "📋 Commit messages from git log:"
           cat /tmp/commits.txt
           echo "📋 File size:"
           wc -l /tmp/commits.txt
 
-          # Fallback: API에서 가져온 커밋이 없으면 git log 시도
+          # Fallback: git log에서 가져온 커밋이 없으면 다른 방법 시도
           if [ ! -s /tmp/commits.txt ]; then
-            echo "⚠️ No commits found with API, trying git log..."
-            git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/commits.txt
-            echo "📋 Git log commit messages:"
+            echo "⚠️ No commits found with git log, trying alternative approach..."
+            # GitHub API를 통해 PR의 커밋 목록 가져오기 (fallback)
+            COMMITS_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/commits)
+            echo "$COMMITS_JSON" | jq -r '.[].commit.message' | head -1 > /tmp/commits.txt
+            echo "📋 Fallback commit messages:"
             cat /tmp/commits.txt
           fi
 

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -25,23 +25,27 @@ jobs:
         run: |
           echo "🔍 Getting PR commits and analyzing..."
 
+          echo "Debug - PR Number: ${{ github.event.number }}"
           echo "Debug - Base SHA: ${{ github.event.pull_request.base.sha }}"
           echo "Debug - Head SHA: ${{ github.event.pull_request.head.sha }}"
 
-          # Get commit messages using git log
-          echo "Running git log command..."
-          git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/commits.txt
+          # GitHub API를 통해 PR의 커밋 목록 가져오기
+          echo "📝 Getting commit list using GitHub API..."
+          COMMITS_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/commits)
+          
+          # 커밋 메시지를 임시 파일에 저장
+          echo "$COMMITS_JSON" | jq -r '.[].commit.message' > /tmp/commits.txt
 
-          echo "📋 Commit messages from file:"
+          echo "📋 Commit messages from API:"
           cat /tmp/commits.txt
           echo "📋 File size:"
           wc -l /tmp/commits.txt
 
-          # Fallback: 파일이 비어있으면 다른 방법 시도
+          # Fallback: API에서 가져온 커밋이 없으면 git log 시도
           if [ ! -s /tmp/commits.txt ]; then
-            echo "⚠️ No commits found with git log, trying alternative approach..."
-            git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | cut -d' ' -f2- > /tmp/commits.txt
-            echo "📋 Alternative commit messages:"
+            echo "⚠️ No commits found with API, trying git log..."
+            git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/commits.txt
+            echo "📋 Git log commit messages:"
             cat /tmp/commits.txt
           fi
 


### PR DESCRIPTION
- 병합된 PR의 커밋 정보를 git log 대신 GitHub API로 가져오도록 수정
- git revision range 오류 방지를 위한 안전한 커밋 정보 추출
- jq를 사용한 JSON 파싱으로 커밋 메시지 첫 줄만 추출
- 오류 처리 및 로깅 개선