### PR TITLE
fix: 중복 CI 체크 제거 - PR에서만 lint/tsc 실행

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-  push:
-    branches: [develop, main]
 
 jobs:
   lint-check:

--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-  push:
-    branches: [develop, main]
 
 jobs:
   typescript-check:


### PR DESCRIPTION
- lint-check.yml, typescript-check.yml에서 push 이벤트 제거
- PR에서만 lint 및 TypeScript 체크 실행하도록 변경
- 중복 테스트 방지로 CI 시간 단축