### PR TITLE
fix: develop 버전 추적 댓글에서 병합된 PR 리스트 누락 문제 해결

### DIFF
--- a/.github/workflows/develop-version-tracker.yml
+++ b/.github/workflows/develop-version-tracker.yml
@@ -87,19 +87,22 @@ jobs:
             
             # 이전에 병합된 모든 PR들을 가져오기
             echo "📋 Getting all previously merged PRs..."
-            MERGED_PRS=$(gh api repos/${{ github.repository }}/pulls \
-              --jq '.[] | select(.base.ref == "develop" and .state == "closed" and .merged_at != null) | "\(.title)|\(.number)"' \
-              | sort -t'|' -k2 -n)
             
+            # 임시 파일에 병합된 PR 정보 저장
+            gh api repos/${{ github.repository }}/pulls \
+              --jq '.[] | select(.base.ref == "develop" and .state == "closed" and .merged_at != null) | "\(.title)|\(.number)"' \
+              | sort -t'|' -k2 -n > /tmp/merged_prs.txt
+            
+            # 임시 파일에서 PR 정보를 읽어서 리스트 생성
             MERGED_PR_LIST=""
-            if [ -n "$MERGED_PRS" ]; then
-              echo "$MERGED_PRS" | while IFS='|' read -r pr_title pr_number; do
+            if [ -s /tmp/merged_prs.txt ]; then
+              while IFS='|' read -r pr_title pr_number; do
                 if [[ -n "$pr_title" && -n "$pr_number" ]]; then
                   MERGED_PR_LIST="$MERGED_PR_LIST
           - [$pr_title](#$pr_number)"
                   echo "✅ Added merged PR: $pr_title (#$pr_number)"
                 fi
-              done
+              done < /tmp/merged_prs.txt
             fi
             
             # 새로운 댓글 생성


### PR DESCRIPTION
- while 루프 서브셸 문제로 인한 변수 누적 실패 수정
- 임시 파일을 사용하여 병합된 PR 정보 처리 방식 개선
- 댓글이 없을 때 이전에 병합된 모든 PR들을 정확히 리스트업하도록 수정
- PR 제목과 링크가 포함된 완전한 병합 히스토리 제공