### PR TITLE
fix: develop 버전 추적 댓글에서 병합된 PR 리스트 생성 방식 단순화

### DIFF
--- a/.github/workflows/develop-version-tracker.yml
+++ b/.github/workflows/develop-version-tracker.yml
@@ -88,22 +88,13 @@ jobs:
             # 이전에 병합된 모든 PR들을 가져오기
             echo "📋 Getting all previously merged PRs..."
             
-            # 임시 파일에 병합된 PR 정보 저장
-            gh api repos/${{ github.repository }}/pulls \
-              --jq '.[] | select(.base.ref == "develop" and .state == "closed" and .merged_at != null) | "\(.title)|\(.number)"' \
-              | sort -t'|' -k2 -n > /tmp/merged_prs.txt
+            # GitHub API에서 병합된 PR들을 가져와서 직접 리스트 생성
+            MERGED_PR_LIST=$(gh api repos/${{ github.repository }}/pulls \
+              --jq '.[] | select(.base.ref == "develop" and .state == "closed" and .merged_at != null) | "- [\(.title)](#\(.number))"' \
+              | sort -t'#' -k2 -n)
             
-            # 임시 파일에서 PR 정보를 읽어서 리스트 생성
-            MERGED_PR_LIST=""
-            if [ -s /tmp/merged_prs.txt ]; then
-              while IFS='|' read -r pr_title pr_number; do
-                if [[ -n "$pr_title" && -n "$pr_number" ]]; then
-                  MERGED_PR_LIST="$MERGED_PR_LIST
-          - [$pr_title](#$pr_number)"
-                  echo "✅ Added merged PR: $pr_title (#$pr_number)"
-                fi
-              done < /tmp/merged_prs.txt
-            fi
+            echo "📋 Found merged PRs:"
+            echo "$MERGED_PR_LIST"
             
             # 새로운 댓글 생성
             COMMENT_BODY="## 📦 Develop 브랜치 버전 상태
@@ -111,7 +102,9 @@ jobs:
           **현재 버전:** \`$CURRENT_VERSION\`  
           **다음 릴리즈 버전:** \`$NEXT_VERSION\`
 
-          ### 🔄 병합된 작업들$MERGED_PR_LIST"
+          ### 🔄 병합된 작업들
+
+          $MERGED_PR_LIST"
 
             gh api repos/${{ github.repository }}/issues/$DEVELOP_TO_MAIN_PR/comments \
               --method POST \


### PR DESCRIPTION
- 복잡한 while 루프 제거하고 jq에서 직접 마크다운 리스트 생성
- GitHub API에서 병합된 PR들을 한 번에 가져와서 리스트 형식으로 변환
- 서브셸 변수 문제 해결로 병합된 PR 리스트가 정확히 표시되도록 수정